### PR TITLE
remove dead code from BaseAvroRecord

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1795,6 +1795,14 @@
       "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
       "dev": true
     },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
     "md5": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
@@ -1807,12 +1815,19 @@
       }
     },
     "mem": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "dev": true,
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-6.0.1.tgz",
+      "integrity": "sha512-uIRYASflIsXqvKe+7aXbLrydaRzz4qiK6amqZDQI++eRtW3UoKtnDcGeCAOREgll7YMxO5E4VB9+3B0LFmy96g==",
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^3.0.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.0.0.tgz",
+          "integrity": "sha512-PiVO95TKvhiwgSwg1IdLYlCTdul38yZxZMIcnDSFIBUm4BNZha2qpQ4GpJ++15bHoKDtrW2D69lMfFwdFYtNZQ=="
+        }
       }
     },
     "mimic-fn": {
@@ -2088,7 +2103,6 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -3271,8 +3285,7 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",
@@ -4728,6 +4741,17 @@
         "execa": "^0.7.0",
         "lcid": "^1.0.0",
         "mem": "^1.1.0"
+      },
+      "dependencies": {
+        "mem": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        }
       }
     },
     "os-tmpdir": {
@@ -4735,6 +4759,11 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
+    },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
     },
     "p-finally": {
       "version": "1.0.0",
@@ -5763,21 +5792,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.1.tgz",
       "integrity": "sha512-h6pM2f/GDchCFlldnriOhs1QHuwbnmj6/v7499eMHqPeW4V2G0elua2eIc2nu8v2NdHV0Gm+tzX83Hr6nUFjQA==",
       "dev": true
-    },
-    "typescript-memoize": {
-      "version": "1.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/typescript-memoize/-/typescript-memoize-1.0.0-alpha.3.tgz",
-      "integrity": "sha1-aZpUFfiGaUqNbi5UUbwoo5prwvk=",
-      "requires": {
-        "core-js": "2.4.1"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-          "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
-        }
-      }
     },
     "typical": {
       "version": "2.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1795,14 +1795,6 @@
       "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
       "dev": true
     },
-    "map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "requires": {
-        "p-defer": "^1.0.0"
-      }
-    },
     "md5": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
@@ -1812,22 +1804,6 @@
         "charenc": "~0.0.1",
         "crypt": "~0.0.1",
         "is-buffer": "~1.1.1"
-      }
-    },
-    "mem": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-6.0.1.tgz",
-      "integrity": "sha512-uIRYASflIsXqvKe+7aXbLrydaRzz4qiK6amqZDQI++eRtW3UoKtnDcGeCAOREgll7YMxO5E4VB9+3B0LFmy96g==",
-      "requires": {
-        "map-age-cleaner": "^0.1.3",
-        "mimic-fn": "^3.0.0"
-      },
-      "dependencies": {
-        "mimic-fn": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.0.0.tgz",
-          "integrity": "sha512-PiVO95TKvhiwgSwg1IdLYlCTdul38yZxZMIcnDSFIBUm4BNZha2qpQ4GpJ++15bHoKDtrW2D69lMfFwdFYtNZQ=="
-        }
       }
     },
     "mimic-fn": {
@@ -4759,11 +4735,6 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
-    },
-    "p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
     },
     "p-finally": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "avsc": "^5.4.13",
     "command-line-args": "^5.0.2",
     "command-line-usage": "^5.0.5",
-    "fs-extra": "^5.0.0",
-    "mem": "^6.0.1"
+    "fs-extra": "^5.0.0"
   },
   "devDependencies": {
     "@degordian/standards": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "command-line-args": "^5.0.2",
     "command-line-usage": "^5.0.5",
     "fs-extra": "^5.0.0",
-    "typescript-memoize": "^1.0.0-alpha.3"
+    "mem": "^6.0.1"
   },
   "devDependencies": {
     "@degordian/standards": "^1.0.8",

--- a/src/components/Avro/BaseAvroRecord.ts
+++ b/src/components/Avro/BaseAvroRecord.ts
@@ -1,26 +1,35 @@
 import * as avro from "avsc";
-import { Schema, Type } from "avsc";
-import { Memoize } from "typescript-memoize";
+import { Type } from "avsc";
+import * as mem from "mem";
 import { AvroRecord } from "./AvroRecord";
+
+function cacheKeyForSchema(schema: any): string {
+    return schema.namespace + schema.name;
+}
+
+const memoizedTypeForSchema = mem(
+    (schema: any): Type => avro.Type.forSchema(schema),
+    { cacheKey: cacheKeyForSchema },
+);
 
 export abstract class BaseAvroRecord implements AvroRecord {
 
     public static readonly subject: string = "";
     public static readonly schema = {};
 
-    @Memoize((schema: any) => {
-        return schema.namespace + schema.name;
-    })
     public static getTypeForSchema(schema: any): Type {
-        return avro.Type.forSchema(schema);
+        return memoizedTypeForSchema(schema);
     }
 
+    /*
+    I don't understand how this works, or where it's used
     @Memoize((schema: any) => {
         return schema.namespace + schema.name;
     })
     public static createTypeResolver(baseType: Type, newType: Type): Type {
         return baseType.createResolver(newType) as Type;
     }
+     */
 
     public abstract schema(): any;
 

--- a/src/components/Avro/BaseAvroRecord.ts
+++ b/src/components/Avro/BaseAvroRecord.ts
@@ -21,16 +21,6 @@ export abstract class BaseAvroRecord implements AvroRecord {
         return memoizedTypeForSchema(schema);
     }
 
-    /*
-    I don't understand how this works, or where it's used
-    @Memoize((schema: any) => {
-        return schema.namespace + schema.name;
-    })
-    public static createTypeResolver(baseType: Type, newType: Type): Type {
-        return baseType.createResolver(newType) as Type;
-    }
-     */
-
     public abstract schema(): any;
 
     public abstract subject(): string;

--- a/src/components/Avro/BaseAvroRecord.ts
+++ b/src/components/Avro/BaseAvroRecord.ts
@@ -1,25 +1,9 @@
-import * as avro from "avsc";
-import { Type } from "avsc";
-import * as mem from "mem";
 import { AvroRecord } from "./AvroRecord";
-
-function cacheKeyForSchema(schema: any): string {
-    return schema.namespace + schema.name;
-}
-
-const memoizedTypeForSchema = mem(
-    (schema: any): Type => avro.Type.forSchema(schema),
-    { cacheKey: cacheKeyForSchema },
-);
 
 export abstract class BaseAvroRecord implements AvroRecord {
 
     public static readonly subject: string = "";
     public static readonly schema = {};
-
-    public static getTypeForSchema(schema: any): Type {
-        return memoizedTypeForSchema(schema);
-    }
 
     public abstract schema(): any;
 


### PR DESCRIPTION
Webpack doesn't like typescript-memoize, and prints this warning:
```Critical dependency: require function is used in a way in which dependencies cannot be statically extracted```

typescript-memoize has been on 1.0.0-alpha.3 release for 3 years without any updates