### PR TITLE
Remove call to addError, as it isn't defined anywhere

### DIFF
--- a/src/components/Converters/RecordConverter.ts
+++ b/src/components/Converters/RecordConverter.ts
@@ -84,7 +84,6 @@ export class RecordConverter extends BaseConverter {
             return `{ [index: string]: ${this.convertType(type.values)} }`;
         }
 
-        this.addError(BaseConverter.errorMessages.TYPE_NOT_FOUND);
         return "any";
     }
 


### PR DESCRIPTION
I'm coming across schema which look something like:

```
protocol x {
  @namespace("foo")
  fixed Code(3);

  record Currency {
    @java-class("java.math.BigDecimal") string amount;
    foo.Code code;
  }
}
```

So `RecordConverter` ends up calling `addError` before returning `"any"`, which doesn't seem to have a body defined anywhere, resulting in an error.

This PR is a small change to sidestep the error.